### PR TITLE
Fix not_reporting multi-condition example

### DIFF
--- a/library/signalfx/detectors/not_reporting/README.md
+++ b/library/signalfx/detectors/not_reporting/README.md
@@ -27,7 +27,7 @@ from signalfx.detectors.not_reporting import conditions
 s = data('memory.utilization')
 
 mem_stopped_reporting = conditions.condition(s)
-mem_too_high = when(s > 90, '12m')
+mem_too_high = when(s.fill() > 90, '12m')
 
 detect(mem_stopped_reporting or mem_too_high).publish()
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I discovered this while trying to replicate the example in our account. After working with support, it became clear the example as written is unlikely to work. If the underlying data stream becomes "null", the logical "or" fails to trigger.

The simplest solution appears to be adding extrapolation or a `fill()`.