### PR TITLE
Fired alert needs context of the metric it was fired on

### DIFF
--- a/library/signalfx/detectors/rum/utils.flow
+++ b/library/signalfx/detectors/rum/utils.flow
@@ -7,7 +7,8 @@ NODE_GROUP_BY = ['sf_node_type',
 GROUP_BY = ['app',
             'sf_environment',
             'sf_product',
-            'workflow.name']
+            'workflow.name',
+            'sf_metric']
 
 _GROUP_BY = ['app',
              'sf_ua_browsername',


### PR DESCRIPTION
To implement the tag spotlight link from fired alert modal, fired alert needs context of the metric it was fired on. This is missing today.

- Adding a group by on sf_metric should help with this. 

