### PR TITLE
fix: remove dead request_rate stream in request_rate_mean_std_detector

### DIFF
--- a/library/signalfx/detectors/autodetect/apm/requests.flow
+++ b/library/signalfx/detectors/autodetect/apm/requests.flow
@@ -20,7 +20,6 @@ def request_rate_mean_std_detector(current_window: duration = duration('10m'),
     # :viz valueSuffix=%
     # :return: detect block that triggers when request rate is too many deviations from the norm established in the preceding window
 
-    streams.request_rate_histograms(filter_=filter_, resource_type='service').publish('Request Rate')
     return sudden_change.detector_mean_std(current_window=current_window, historical_window=historical_window,
                                            fire_num_stddev=fire_num_stddev,
                                            clear_num_stddev=clear_num_stddev,


### PR DESCRIPTION
The first line of request_rate_mean_std_detector computed and published a Request Rate MTS via streams.request_rate_histograms() that was never referenced. 
detector_mean_std (via sudden_change.detector_mean_std) does its own internal data fetch, making this publish a no-op that wastes MTS.